### PR TITLE
fixed compatibility with current ofBase types.

### DIFF
--- a/src/ofxKinectForWindows2/Device.cpp
+++ b/src/ofxKinectForWindows2/Device.cpp
@@ -166,7 +166,7 @@ namespace ofxKinectForWindows2 {
 
 		if (colorSource) {
 			//bind kinect color camera texture and draw mesh from depth (which has texture coordinates)
-			colorSource->getTextureReference().bind();
+			colorSource->getTexture().bind();
 		}
 
 		auto opts = Source::Depth::PointCloudOptions(true, Source::Depth::PointCloudOptions::TextureCoordinates::ColorCamera);
@@ -185,7 +185,7 @@ namespace ofxKinectForWindows2 {
 		
 		if (colorSource) {
 			//unbind colour camera
-			colorSource->getTextureReference().unbind();
+			colorSource->getTexture().unbind();
 		}
 
 		ofPopStyle();

--- a/src/ofxKinectForWindows2/Source/BaseImage.cpp
+++ b/src/ofxKinectForWindows2/Source/BaseImage.cpp
@@ -45,9 +45,16 @@ namespace ofxKinectForWindows2 {
 
 		//----------
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
-		ofTexture & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getTextureReference() {
+		ofTexture & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getTexture() {
 			return this->texture;
 		}
+
+		//----------
+		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
+		const ofTexture & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getTexture() const {
+			return this->texture;
+		}
+
 
 		//----------
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
@@ -60,13 +67,13 @@ namespace ofxKinectForWindows2 {
 
 		//----------
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
-		PixelType * BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getPixels() {
-			return this->pixels.getPixels();
+		ofPixels_<PixelType> & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getPixels() {
+			return this->pixels;
 		}
 
-		//----------
+				//----------
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
-		ofPixels_<PixelType> & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getPixelsRef() {
+		const ofPixels_<PixelType> & BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::getPixels() const {
 			return this->pixels;
 		}
 

--- a/src/ofxKinectForWindows2/Source/BaseImage.h
+++ b/src/ofxKinectForWindows2/Source/BaseImage.h
@@ -22,18 +22,20 @@ namespace ofxKinectForWindows2 {
 			ReaderType * getReader();
 
 			//ofBaseHasTexture
-			ofTexture & getTextureReference() override;
+			ofTexture & getTexture() override;
+			const ofTexture & getTexture() const override;
 			void setUseTexture(bool) override;
+			bool isUsingTexture() const override { return useTexture; }
 
 			//ofBaseHasPixels
-			PixelType * getPixels() override;
-			ofPixels_<PixelType> & getPixelsRef() override;
+			ofPixels_<PixelType> & getPixels() override;
+			const ofPixels_<PixelType> & getPixels() const override;
 
 			//ofBaseDraws
-			void draw(float, float) override;
-			void draw(float, float, float, float) override;
-			float getWidth() override;
-			float getHeight() override;
+			void draw(float, float) const override;
+			void draw(float, float, float, float) const override;
+			float getWidth() const override;
+			float getHeight() const override;
 
 			float getDiagonalFieldOfView() const;
 			float getHorizontalFieldOfView() const;


### PR DESCRIPTION
It seems that a lot of the ofBase types are different to what you're working against (const correctness, const and non-const getters, dropping Ref suffixes etc.). so code wasn't compiling (bless the new override keyword and pure virtual methods!). I've fixed these. 
