### PR TITLE
Fix bug where depth frame copy ignored pixel size

### DIFF
--- a/src/ofxKinectForWindows2/Source/BaseImage.cpp
+++ b/src/ofxKinectForWindows2/Source/BaseImage.cpp
@@ -160,7 +160,7 @@ namespace ofxKinectForWindows2 {
 				}
 
 				//update local assets
-				if (FAILED(frame->CopyFrameDataToArray(this->pixels.size(), this->pixels.getPixels()))) {
+				if (FAILED(frame->CopyFrameDataToArray(this->pixels.size() / this->pixels.getBytesPerPixel(), this->pixels.getPixels()))) {
 					throw Exception("Couldn't pull pixel buffer ");
 				}
 				if (this->useTexture) {


### PR DESCRIPTION
CopyFrameDataToArray was returning E_INVALIDARG when copying 16-bit depth frames. I'm not sure why this would only affect me, but without this fix I get..
```
[ error ] ofxKinectForWindows2::Source::BaseImageSimple<unsigned short,struct IDepthFrameReader,struct IDepthFrame>::update: Couldn't pull pixel buffer
```
..spammed in the console when running the example, and the depth frame & infrared frames weren't shown. After this I get the expected super-dark depth image & infrared.

OF master, VS2012, Windows 8, Kinect SDK current as of Feb 12 2015