### PR TITLE
Fixed aspect ratio and added body source to example

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -1,5 +1,8 @@
 #include "ofApp.h"
 
+int previewWidth = 640;
+int previewHeight = 480;
+
 //--------------------------------------------------------------
 void ofApp::setup(){
 	kinect.open();
@@ -8,20 +11,34 @@ void ofApp::setup(){
 	kinect.initInfraredSource();
 	kinect.initBodyIndexSource();
 
-	ofSetWindowShape(640 * 2, 480 * 2);
+	ofSetWindowShape(previewWidth * 2, previewHeight * 2);
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
-	this->kinect.update();
+	kinect.update();
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	this->kinect.getDepthSource()->draw(0,0,640,480); // note that the depth texture is RAW so may appear dark
-	this->kinect.getColorSource()->draw(640,0,640,480);
-	this->kinect.getInfraredSource()->draw(0,480,640,480);
-	this->kinect.getBodyIndexSource()->draw(640,480,640,480);
+	float sourceRatio;
+	float sourceHeight;
+
+	sourceRatio = kinect.getDepthSource()->getHeight() / kinect.getDepthSource()->getWidth();
+	sourceHeight = previewWidth * sourceRatio; 
+	kinect.getDepthSource()->draw(0, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);  // note that the depth texture is RAW so may appear dark
+	
+	sourceRatio = kinect.getColorSource()->getHeight() / kinect.getColorSource()->getWidth();
+	sourceHeight = previewWidth * sourceRatio; 
+	kinect.getColorSource()->draw(previewWidth, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	
+	sourceRatio = kinect.getInfraredSource()->getHeight() / kinect.getInfraredSource()->getWidth();
+	sourceHeight = previewWidth * sourceRatio; 
+	kinect.getInfraredSource()->draw(0, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	
+	sourceRatio = kinect.getBodyIndexSource()->getHeight() / kinect.getBodyIndexSource()->getWidth();
+	sourceHeight = previewWidth * sourceRatio; 
+	kinect.getBodyIndexSource()->draw(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -9,6 +9,7 @@ void ofApp::setup(){
 	kinect.initDepthSource();
 	kinect.initColorSource();
 	kinect.initInfraredSource();
+	kinect.initBodySource();
 	kinect.initBodyIndexSource();
 
 	ofSetWindowShape(previewWidth * 2, previewHeight * 2);
@@ -31,6 +32,7 @@ void ofApp::draw(){
 	sourceRatio = kinect.getColorSource()->getHeight() / kinect.getColorSource()->getWidth();
 	sourceHeight = previewWidth * sourceRatio; 
 	kinect.getColorSource()->draw(previewWidth, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	kinect.getBodySource()->drawProjected(previewWidth, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
 	
 	sourceRatio = kinect.getInfraredSource()->getHeight() / kinect.getInfraredSource()->getWidth();
 	sourceHeight = previewWidth * sourceRatio; 
@@ -39,6 +41,7 @@ void ofApp::draw(){
 	sourceRatio = kinect.getBodyIndexSource()->getHeight() / kinect.getBodyIndexSource()->getWidth();
 	sourceHeight = previewWidth * sourceRatio; 
 	kinect.getBodyIndexSource()->draw(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	kinect.getBodySource()->drawProjected(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight, ofxKFW2::DepthCamera);
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -22,26 +22,18 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	float sourceRatio;
-	float sourceHeight;
-
-	sourceRatio = kinect.getDepthSource()->getHeight() / kinect.getDepthSource()->getWidth();
-	sourceHeight = previewWidth * sourceRatio; 
-	kinect.getDepthSource()->draw(0, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);  // note that the depth texture is RAW so may appear dark
+	kinect.getDepthSource()->draw(0, 0, previewWidth, previewHeight);  // note that the depth texture is RAW so may appear dark
 	
-	sourceRatio = kinect.getColorSource()->getHeight() / kinect.getColorSource()->getWidth();
-	sourceHeight = previewWidth * sourceRatio; 
-	kinect.getColorSource()->draw(previewWidth, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
-	kinect.getBodySource()->drawProjected(previewWidth, 0 + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	// Color is at 1920x1080 instead of 512x424 so we should fix aspect ratio
+	float colorHeight = previewWidth * (kinect.getColorSource()->getHeight() / kinect.getColorSource()->getWidth());
+	float colorTop = (previewHeight - colorHeight) / 2.0;
+	kinect.getColorSource()->draw(previewWidth, 0 + colorTop, previewWidth, colorHeight);
+	kinect.getBodySource()->drawProjected(previewWidth, 0 + colorTop / 2.0, previewWidth, colorHeight);
 	
-	sourceRatio = kinect.getInfraredSource()->getHeight() / kinect.getInfraredSource()->getWidth();
-	sourceHeight = previewWidth * sourceRatio; 
-	kinect.getInfraredSource()->draw(0, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
+	kinect.getInfraredSource()->draw(0, previewHeight, previewWidth, previewHeight);
 	
-	sourceRatio = kinect.getBodyIndexSource()->getHeight() / kinect.getBodyIndexSource()->getWidth();
-	sourceHeight = previewWidth * sourceRatio; 
-	kinect.getBodyIndexSource()->draw(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
-	kinect.getBodySource()->drawProjected(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight, ofxKFW2::ProjectionCoordinates::DepthCamera);
+	kinect.getBodyIndexSource()->draw(previewWidth, previewHeight, previewWidth, previewHeight);
+	kinect.getBodySource()->drawProjected(previewWidth, previewHeight, previewWidth, previewHeight, ofxKFW2::ProjectionCoordinates::DepthCamera);
 }
 
 //--------------------------------------------------------------

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -28,7 +28,7 @@ void ofApp::draw(){
 	float colorHeight = previewWidth * (kinect.getColorSource()->getHeight() / kinect.getColorSource()->getWidth());
 	float colorTop = (previewHeight - colorHeight) / 2.0;
 	kinect.getColorSource()->draw(previewWidth, 0 + colorTop, previewWidth, colorHeight);
-	kinect.getBodySource()->drawProjected(previewWidth, 0 + colorTop / 2.0, previewWidth, colorHeight);
+	kinect.getBodySource()->drawProjected(previewWidth, 0 + colorTop, previewWidth, colorHeight);
 	
 	kinect.getInfraredSource()->draw(0, previewHeight, previewWidth, previewHeight);
 	

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -41,7 +41,7 @@ void ofApp::draw(){
 	sourceRatio = kinect.getBodyIndexSource()->getHeight() / kinect.getBodyIndexSource()->getWidth();
 	sourceHeight = previewWidth * sourceRatio; 
 	kinect.getBodyIndexSource()->draw(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight);
-	kinect.getBodySource()->drawProjected(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight, ofxKFW2::DepthCamera);
+	kinect.getBodySource()->drawProjected(previewWidth, previewHeight + (previewHeight - sourceHeight) / 2.0, previewWidth, sourceHeight, ofxKFW2::ProjectionCoordinates::DepthCamera);
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Thought you might want to merge this in:
* Fixed the aspect ratio on the drawn images so that they aren't squished.
* Added projected bodies (skeletons) drawing, so that all the 2D stuff can be shown in a single example.