### PR TITLE
Add BaseImage::isFrameNew()

### DIFF
--- a/src/ofxKinectForWindows2/Source/BaseImage.cpp
+++ b/src/ofxKinectForWindows2/Source/BaseImage.cpp
@@ -19,7 +19,7 @@ namespace ofxKinectForWindows2 {
 			this->horizontalFieldOfView = 0.0f;
 			this->verticalFieldOfView = 0.0f;
 			this->lastFrameTime = 0;
-			this->isFrameNew = false;
+			this->bIsFrameNew = false;
 
 			if (this->frustumMesh.getVertices().empty()) {
 				this->frustumMesh.addVertex(ofVec3f(0.0f, 0.0f, 0.0f));
@@ -123,8 +123,8 @@ namespace ofxKinectForWindows2 {
 
 		//----------
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
-		bool BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::IsFrameNew() const {
-		return this->isFrameNew;
+		bool BaseImage OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::isFrameNew() const {
+			return this->bIsFrameNew;
 		}
 
 		//----------
@@ -145,7 +145,7 @@ namespace ofxKinectForWindows2 {
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS
 		void BaseImageSimple OFXKFW2_BaseImageSimple_TEMPLATE_ARGS_TRIM::update() {
 			CHECK_OPEN
-			isFrameNew = false;
+			bIsFrameNew = false;
 			FrameType * frame = NULL;
 			IFrameDescription * frameDescription = NULL;
 			try {
@@ -161,7 +161,7 @@ namespace ofxKinectForWindows2 {
 				
 				if (relativeTime > lastFrameTime) {
 					relativeTime = lastFrameTime;
-					isFrameNew = true;
+					bIsFrameNew = true;
 				} 
 				else {
 					SafeRelease(frame);

--- a/src/ofxKinectForWindows2/Source/BaseImage.h
+++ b/src/ofxKinectForWindows2/Source/BaseImage.h
@@ -42,6 +42,8 @@ namespace ofxKinectForWindows2 {
 			float getVerticalFieldOfView() const;
 
 			void drawFrustum() const;
+
+			bool IsFrameNew() const;
 		protected:
 			static ofMesh frustumMesh;
 
@@ -53,6 +55,8 @@ namespace ofxKinectForWindows2 {
 			float diagonalFieldOfView;
 			float horizontalFieldOfView;
 			float verticalFieldOfView;
+			INT64 lastFrameTime;
+			bool  isFrameNew;
 		};
 
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS

--- a/src/ofxKinectForWindows2/Source/BaseImage.h
+++ b/src/ofxKinectForWindows2/Source/BaseImage.h
@@ -43,7 +43,7 @@ namespace ofxKinectForWindows2 {
 
 			void drawFrustum() const;
 
-			bool IsFrameNew() const;
+			bool isFrameNew() const;
 		protected:
 			static ofMesh frustumMesh;
 
@@ -55,8 +55,8 @@ namespace ofxKinectForWindows2 {
 			float diagonalFieldOfView;
 			float horizontalFieldOfView;
 			float verticalFieldOfView;
-			INT64 lastFrameTime;
-			bool  isFrameNew;
+			long  lastFrameTime;
+			bool  bIsFrameNew;
 		};
 
 		template OFXKFW2_BaseImageSimple_TEMPLATE_ARGS


### PR DESCRIPTION
A replacement for https://github.com/elliotwoods/ofxKinectForWindows2/pull/31 with fixes to code style. Thanks to @nickdevereaux for the original work! New variable/method names are based on the usage in ofxKinect.

I also changed lastFrameTime from INT64 to long based on your comments here https://github.com/elliotwoods/ofxKinectForWindows2/pull/32#discussion_r30300894.

I did minimal testing here but it looks functional. kinect.getDepthSource()->isFrameNew() is returning true every other frame for an app running at 60fps.