### PR TITLE
Restore accidentally-deleted shaders from exampleBodyIndexShader

### DIFF
--- a/exampleBodyIndexShader/bin/data/shaders/bodyIndex.frag
+++ b/exampleBodyIndexShader/bin/data/shaders/bodyIndex.frag
@@ -1,0 +1,13 @@
+#version 120
+
+uniform sampler2DRect uColorTex;
+
+void main()
+{
+	if (gl_Color.a == 0.0) {
+		discard;
+	}
+
+	vec4 color = texture2DRect(uColorTex, gl_TexCoord[0].st);
+	gl_FragColor = color;
+}

--- a/exampleBodyIndexShader/bin/data/shaders/bodyIndex.vert
+++ b/exampleBodyIndexShader/bin/data/shaders/bodyIndex.vert
@@ -1,0 +1,21 @@
+#version 120
+#extension GL_EXT_gpu_shader4 : require
+
+uniform sampler2DRect uBodyIndexTex;
+uniform int uWidth;
+
+void main()
+{ 
+	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+	gl_TexCoord[0] = gl_MultiTexCoord1;
+
+	vec2 bIdxTexCoord = vec2(gl_VertexID % uWidth, gl_VertexID / uWidth);
+	vec4 bIdxColor = texture2DRect(uBodyIndexTex, bIdxTexCoord);
+
+	if (bIdxColor.rgb == vec3(1.0, 1.0, 1.0)) {
+		gl_FrontColor = vec4(0.0, 0.0, 0.0, 0.0);
+	}
+	else {
+		gl_FrontColor = vec4(1.0, 1.0, 1.0, 1.0);
+	}
+}


### PR DESCRIPTION
Just realized that the shaders were deleted when I renamed the shader example project, so they're added back in this PR

https://github.com/elliotwoods/ofxKinectForWindows2/commit/935119d58e32aab41ee9ad8f389d276f8f5341f7