### PR TITLE
compatibility with nightly (v0.10.0) build of Project Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Try the examples to see if they build and run. Then try with your own project:
 3. In `Property Manager` (open it from `View -> Other Windows -> Property Manager`), right click on your project to select `Add Existing Property Sheet...` and select the `ofxKinectForWindows2.props` file.
 4. Go back to `Solution Explorer`, right click on your project (e.g. 'mySketch') and select 'Add Reference...', and add a reference to `ofxKinectForWindows2Lib`.
 
+### Alternative Usage with OF Project Generator 
+
+This method requires the [OF nightly build](http://ci.openframeworks.cc/nightlybuilds.html) of Project Generator.  It will not work with the Project Generator from OF 0.9.8 or earlier.
+
+1. Make your project with Project Generator, **including** the ofxKinectForWindows2 addon, and open in IDE
+2. In `Property Manager` (open it from `View -> Other Windows -> Property Manager`), right click on your project to select `Add Existing Property Sheet...` and select the `ofxKinectForWindows2.props` file.
+
+
 ## Notes
 
 0. The depth image comes in as 'RAW' mm values (i'm not amplifying the values), so it may appear dark. Look closely :)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Try the examples to see if they build and run. Then try with your own project:
 
 This method requires the [OF nightly build](http://ci.openframeworks.cc/nightlybuilds.html) of Project Generator.  It will not work with the Project Generator from OF 0.9.8 or earlier.
 
-1. Make your project with Project Generator, **including** the ofxKinectForWindows2 addon, and open in IDE
+1. Make your project with Project Generator, **including** the ofxKinectForWindows2 addon, and open in IDE (Visual Studio 2015)
 2. In `Property Manager` (open it from `View -> Other Windows -> Property Manager`), right click on your project to select `Add Existing Property Sheet...` and select the `ofxKinectForWindows2.props` file.
 
 

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -1,0 +1,82 @@
+# All variables and this file are optional, if they are not present the PG and the
+# makefiles will try to parse the correct values from the file system.
+#
+# Variables that specify exclusions can use % as a wildcard to specify that anything in
+# that position will match. A partial path can also be specified to, for example, exclude
+# a whole folder from the parsed paths from the file system
+#
+# Variables can be specified using = or +=
+# = will clear the contents of that variable both specified from the file or the ones parsed
+# from the file system
+# += will add the values to the previous ones in the file or the ones parsed from the file 
+# system
+# 
+# The PG can be used to detect errors in this file, just create a new project with this addon 
+# and the PG will write to the console the kind of error and in which line it is
+
+meta:
+	# ADDON_NAME = 
+	# ADDON_DESCRIPTION =
+	# ADDON_AUTHOR =
+	# ADDON_TAGS =
+	# ADDON_URL =
+
+common:
+	# dependencies with other addons, a list of them separated by spaces 
+	# or use += in several lines
+	# ADDON_DEPENDENCIES =
+	
+	# include search paths, this will be usually parsed from the file system
+	# but if the addon or addon libraries need special search paths they can be
+	# specified here separated by spaces or one per line using +=
+	
+	# any special flag that should be passed to the compiler when using this
+	# addon
+	# ADDON_CFLAGS =
+	
+	# any special flag that should be passed to the linker when using this
+	# addon, also used for system libraries with -lname
+	# ADDON_LDFLAGS = 
+	
+	# linux only, any library that should be included in the project using
+	# pkg-config
+	# ADDON_PKG_CONFIG_LIBRARIES =
+	
+	# osx/iOS only, any framework that should be included in the project
+	# ADDON_FRAMEWORKS =
+	
+	# source files, these will be usually parsed from the file system looking
+	# in the src folders in libs and the root of the addon. if your addon needs
+	# to include files in different places or a different set of files per platform
+	# they can be specified here
+	# ADDON_SOURCES =
+	
+	# some addons need resources to be copied to the bin/data folder of the project
+	# specify here any files that need to be copied, you can use wildcards like * and ?
+	# ADDON_DATA = 
+	
+	# when parsing the file system looking for libraries exclude this for all or
+	# a specific platform
+	# ADDON_LIBS_EXCLUDE =
+
+vs:
+
+	ADDON_INCLUDES += $(KINECTSDK20_DIR)inc
+	ADDON_LIBS += $(KINECTSDK20_DIR)Lib\$(PlatformTarget)\Kinect20.lib
+	
+linux64:
+	# binary libraries, these will be usually parsed from the file system but some 
+	# libraries need to passed to the linker in a specific order/
+	# 
+	# For example in the ofxOpenCV addon we do something like this:
+	#
+	# ADDON_LIBS =
+	# ADDON_LIBS += libs/opencv/lib/linuxarmv6l/libopencv_legacy.a
+	# ADDON_LIBS += libs/opencv/lib/linuxarmv6l/libopencv_calib3d.a
+	# ...
+linux:
+win_cb:
+linuxarmv6l:
+linuxarmv7l:
+android/armeabi:	
+android/armeabi-v7a:	

--- a/ofxKinectForWindows2.props
+++ b/ofxKinectForWindows2.props
@@ -6,6 +6,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(KINECTSDK20_DIR)\inc;..\..\..\addons\ofxKinectForWindows2\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/ofxKinectForWindows2Lib/ofxKinectForWindows2Lib.vcxproj
+++ b/ofxKinectForWindows2Lib/ofxKinectForWindows2Lib.vcxproj
@@ -82,7 +82,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <MinimalRebuild>false</MinimalRebuild>
-      <ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName>
+      <!-- ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName -->
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -99,7 +99,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <MinimalRebuild>false</MinimalRebuild>
-      <ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName>
+      <!-- ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName -->
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -116,7 +116,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName>
+      <!-- ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName -->
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -136,7 +136,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName>
+      <!-- ObjectFileName>$(IntDir)\%(Directory)\</ObjectFileName -->
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
2 commits aimed at streamlining project generation through OF Project Geneator:

- [added addon_config.mk](https://github.com/tyhenry/ofxKinectForWindows2/blob/PG/addon_config.mk) to automatically include/link Kinect 2.0 SDK when using Project Generator
  note: this only works with nightly build of OF Project Generator due to bug in PG in OF 0.9.8 and earlier

```
    vs:
	ADDON_INCLUDES += $(KINECTSDK20_DIR)inc
	ADDON_LIBS += $(KINECTSDK20_DIR)Lib\$(PlatformTarget)\Kinect20.lib
```

- [modified ofxKinectForWindows2.props](https://github.com/tyhenry/ofxKinectForWindows2/blob/PG/ofxKinectForWindows2.props#L9) to alter C/C++ > Output Files > Object File Name to `$(InitDir)\%(Directory)\`
    This prevents compilation errors on VS due to \Source\Body.cpp and \Data\Body.cpp naming conflict     

- [updated README.md with extra instructions](https://github.com/tyhenry/ofxKinectForWindows2/blob/PG/README.md#alternative-usage-with-of-project-generator) for using as a standard addon with Project Generator
    1. use project generator, including ofxKinectForWindows2 addon
    2. add ofxKinectForWindows2.props to project
